### PR TITLE
fix: don't use `removeprefix` for pythom 3.8 (colab)

### DIFF
--- a/scripts/tagger.py
+++ b/scripts/tagger.py
@@ -361,10 +361,10 @@ def on_ui_tabs():
                         continue
 
                     # guess the output path
-                    output_dir = Path(
-                        base_dir if batch_output_dir == '' else batch_output_dir,
-                        os.path.dirname(str(path).removeprefix(base_dir + '/'))
-                    )
+                    base_dir_last = Path(base_dir).parts[-1]
+                    base_dir_last_idx = path.parts.index(base_dir_last)
+                    output_dir = Path(batch_output_dir) if batch_output_dir else Path(base_dir)
+                    output_dir = output_dir.joinpath(*path.parts[base_dir_last_idx + 1:]).parent
 
                     output_dir.mkdir(0o777, True, True)
 


### PR DESCRIPTION
## problem

`.removeprefix` 메소드는 파이썬 3.9에 새로 생긴 함수고, 아직 3.8을 쓰는 코랩에서 오류가 납니다.

## solution

base_dir이 

`path1/path2/base_dir/`

이고, 이 안에 이미지가

`path1/path2/base_dir/folder1/image1.jpg`

처럼 들어있을 때,

batch_output_dir이

`output_path/` 이면,

output_dir은

`output_path/folder1/`

처럼 되어야 합니다.

`.removeprefix`를 사용해서 구현되어 있던걸 `.removeprefix`없이 똑같이 동작하도록 만들었습니다.

그래도 어떤 오류가 있을지 모르니 테스트는 꼭 해보시고 적용해주세요.