### PR TITLE
Fix: Splitting empty string returns an empty tag

### DIFF
--- a/tagger/utils.py
+++ b/tagger/utils.py
@@ -2,4 +2,4 @@ from typing import List
 
 
 def split_str(s: str, separator=',') -> List[str]:
-    return list(map(str.strip, s.split(separator)))
+    return [x.strip() for x in s.split(separator) if x]


### PR DESCRIPTION
An unnecessary comma will be added at the beginning when the exclude tags are set but the additional tags are empty.

![image](https://user-images.githubusercontent.com/60182057/213950823-80924aca-4325-41f9-bcca-b4fe76ebf3a5.png)
![image](https://user-images.githubusercontent.com/60182057/213951057-7ef9d2b7-813b-4f79-b29f-70c6996d35bb.png)
