### PR TITLE
Fixing additional tags not showing in the result tags

### DIFF
--- a/tagger/interrogator.py
+++ b/tagger/interrogator.py
@@ -51,6 +51,8 @@ class Interrogator:
             **{t: 1.0 for t in additional_tags},
             **tags
         }
+        for t in additional_tags:
+            tags[t] = 1.0
 
         # those lines are totally not "pythonic" but looks better to me
         tags = {


### PR DESCRIPTION
Fixing additional tags not showing in the result tags
https://github.com/toriato/stable-diffusion-webui-wd14-tagger/issues/41

- Before:
![image](https://user-images.githubusercontent.com/5293796/215440534-6021c92e-47b5-4e1e-ad9c-23aecd029713.png)

- After:
![image](https://user-images.githubusercontent.com/5293796/215440497-31141204-9949-49b6-8648-013b3ebfe503.png)
