### PR TITLE
Add UI element & logic for only tagging specified tags

### DIFF
--- a/tagger/interrogator.py
+++ b/tagger/interrogator.py
@@ -64,7 +64,7 @@ class Interrogator:
             # filter tags
             if (
                 c >= threshold
-                and (len(include_tags) == 0 or t in include_tags)
+                and (not include_tags or t in include_tags)
                 and t not in exclude_tags
             )
         }

--- a/tagger/interrogator.py
+++ b/tagger/interrogator.py
@@ -40,6 +40,7 @@ class Interrogator:
         threshold=0.35,
         additional_tags: List[str] = [],
         exclude_tags: List[str] = [],
+        include_tags: List[str] = [],
         sort_by_alphabetical_order=False,
         add_confident_as_weight=False,
         replace_underscore=False,
@@ -63,6 +64,7 @@ class Interrogator:
             # filter tags
             if (
                 c >= threshold
+                and (len(include_tags) == 0 or t in include_tags)
                 and t not in exclude_tags
             )
         }

--- a/tagger/ui.py
+++ b/tagger/ui.py
@@ -40,6 +40,7 @@ def on_interrogate(
     threshold: float,
     additional_tags: str,
     exclude_tags: str,
+    include_tags: str,
     sort_by_alphabetical_order: bool,
     add_confident_as_weight: bool,
     replace_underscore: bool,
@@ -57,6 +58,7 @@ def on_interrogate(
         threshold,
         split_str(additional_tags),
         split_str(exclude_tags),
+        split_str(include_tags),
         sort_by_alphabetical_order,
         add_confident_as_weight,
         replace_underscore,
@@ -369,6 +371,12 @@ def on_ui_tabs():
                     elem_id='exclude-tags'
                 )
 
+                include_tags = utils.preset.component(
+                    gr.Textbox,
+                    label='Only include these tags (split by comma)',
+                    elem_id='include-tags'
+                )
+
                 sort_by_alphabetical_order = utils.preset.component(
                     gr.Checkbox,
                     label='Sort by alphabetical order',
@@ -463,6 +471,7 @@ def on_ui_tabs():
                     threshold,
                     additional_tags,
                     exclude_tags,
+                    include_tags,
                     sort_by_alphabetical_order,
                     add_confident_as_weight,
                     replace_underscore,


### PR DESCRIPTION
Currently, while there is a way to (always) add tags (`additional tags`) and exclude tags, there is no way to make use of this extension to add only 1 or more specified tags if each tag meets the threshold. This use case is particularly helpful when trying to tag different tags at different confidence thresholds, or when trying to minimize the impact of tagging images with existing tags.

Tested in latest version. Sample test case:
- Single process for an image with 1girl, 1boy
- Add `1boy` to `Exclude tags`
- Add `1girl, 1boy` to `Only include these tags`
- Interrogate. Tags result should be `1girl`