### PR TITLE
fix: failed to install onnxruntime package on MacOS

### DIFF
--- a/tagger/interrogator.py
+++ b/tagger/interrogator.py
@@ -241,10 +241,15 @@ class WaifuDiffusionInterrogator(Interrogator):
         # https://onnxruntime.ai/docs/get-started/with-python.html#install-onnx-runtime
         # TODO: remove old package when the environment changes?
         from launch import is_installed, run_pip
+        from platform import system
+        package_name = "onnxruntime-gpu"
+        if system() == "Darwin":
+            package_name = "onnxruntime-silicon"
+
         if not is_installed('onnxruntime'):
             package = os.environ.get(
                 'ONNXRUNTIME_PACKAGE',
-                'onnxruntime-gpu'
+                package_name
             )
 
             run_pip(f'install {package}', 'onnxruntime')


### PR DESCRIPTION
When using tagger on MacOS, the following error occurs:
```
ERROR: Could not find a version that satisfies the requirement onnxruntime-gpu (from versions: none)
ERROR: No matching distribution found for onnxruntime-gpu
```
The package name of onnxruntime on macos is different, it should be `onnxruntime-silicon`