### PR TITLE
deepdanbooru projects path error handling

### DIFF
--- a/tagger/utils.py
+++ b/tagger/utils.py
@@ -70,7 +70,10 @@ def refresh_interrogators() -> List[str]:
     for path in os.scandir(deepdanbooru_projects_path):
         if not path.is_dir():
             continue
-
+        
+        if not Path(path, 'project.json').is_file():
+            continue
+        
         interrogators[path.name] = DeepDanbooruInterrogator(path.name, path)
 
     return sorted(interrogators.keys())

--- a/tagger/utils.py
+++ b/tagger/utils.py
@@ -61,17 +61,14 @@ def refresh_interrogators() -> List[str]:
         ),
     }
 
+
     # load deepdanbooru project
-    os.makedirs(
-        getattr(shared.cmd_opts, 'deepdanbooru_projects_path', default_ddp_path),
-        exist_ok=True
-    )
+    deepdanbooru_projects_path = getattr(shared.cmd_opts, 'deepdanbooru_projects_path', default_ddp_path)
 
-    for path in os.scandir(shared.cmd_opts.deepdanbooru_projects_path):
+    os.makedirs(deepdanbooru_projects_path, exist_ok=True)
+
+    for path in os.scandir(deepdanbooru_projects_path):
         if not path.is_dir():
-            continue
-
-        if not Path(path, 'project.json').is_file():
             continue
 
         interrogators[path.name] = DeepDanbooruInterrogator(path.name, path)


### PR DESCRIPTION
```
os.makedirs(deepdanbooru_projects_path, exist_ok=True)
for path in os.scandir(deepdanbooru_projects_path):
```

This commit addresses the issue of a non-existent deepdanbooru_projects_path attribute in the shared.cmd_opts object. 