### PR TITLE
weighed combination and combined stats, in shorter list and several fixes and updates to the ui

### DIFF
--- a/javascript/tagger.js
+++ b/javascript/tagger.js
@@ -78,6 +78,9 @@ document.addEventListener('DOMContentLoaded', () => {
         function onClickLabels(e) {
             // find clicked label item's wrapper element
             const tag = e.target.innerText;
+            if (tag.endsWith('%')) {
+                return
+            }
 
             // ignore if tag is already exist in textbox
             const escapedTag = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')

--- a/javascript/tagger.js
+++ b/javascript/tagger.js
@@ -43,7 +43,7 @@ function waitQuerySelector(selector, timeout = 5000, $rootElement = gradioApp())
 document.addEventListener('DOMContentLoaded', () => {
     Promise.all([
         // option texts
-        waitQuerySelector('#additioanl-tags'),
+        waitQuerySelector('#additional-tags'),
         waitQuerySelector('#exclude-tags'),
 
         // tag-confident labels

--- a/javascript/tagger.js
+++ b/javascript/tagger.js
@@ -77,13 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
          */
         function onClickLabels(e) {
             // find clicked label item's wrapper element
-            const $tag = e.target.closest('.output-label > div:not(:first-child)')
-            if (!$tag) {
-                return
-            }
-
-            /** @type {string} */
-            const tag = $tag.querySelector('.leading-snug').textContent
+            const tag = e.target.innerText;
 
             // ignore if tag is already exist in textbox
             const escapedTag = tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')

--- a/preload.py
+++ b/preload.py
@@ -4,6 +4,7 @@ from argparse import ArgumentParser
 from modules.shared import models_path
 
 default_ddp_path = Path(models_path, 'deepdanbooru')
+default_onnx_path = Path(models_path, 'TaggerOnnx')
 
 
 def preload(parser: ArgumentParser):
@@ -17,3 +18,10 @@ def preload(parser: ArgumentParser):
         help='Path to directory with DeepDanbooru project(s).',
         default=default_ddp_path
     )
+    parser.add_argument(
+        '--onnxtagger-path',
+        type=str,
+        help='Path to directory with DeepDanbooru project(s).',
+        default=default_onnx_path
+    )
+

--- a/preload.py
+++ b/preload.py
@@ -21,7 +21,7 @@ def preload(parser: ArgumentParser):
     parser.add_argument(
         '--onnxtagger-path',
         type=str,
-        help='Path to directory with DeepDanbooru project(s).',
+        help='Path to directory with Onnyx project(s).',
         default=default_onnx_path
     )
 

--- a/tagger/ui.py
+++ b/tagger/ui.py
@@ -80,7 +80,7 @@ def on_interrogate(
         return [
             ', '.join(processed_tags.keys() if add_confident_as_weight else processed_tags),
             ratings,
-            tags,
+            dict(filter(lambda x: x[1] >= threshold / 2, tags.items())),
             ''
         ]
 

--- a/tagger/ui.py
+++ b/tagger/ui.py
@@ -504,7 +504,7 @@ def on_ui_tabs():
                 additional_tags = utils.preset.component(
                     gr.Textbox,
                     label='Additional tags (split by comma)',
-                    elem_id='additioanl-tags'
+                    elem_id='additional-tags'
                 )
 
                 exclude_tags = utils.preset.component(

--- a/tagger/ui.py
+++ b/tagger/ui.py
@@ -39,6 +39,7 @@ def on_interrogate(
 
     interrogator: str,
     threshold: float,
+    tag_count_threshold: float,
     additional_tags: str,
     exclude_tags: str,
     sort_by_alphabetical_order: bool,
@@ -204,6 +205,10 @@ def on_interrogate(
                 tags,
                 *postprocess_opts
             )
+            if tag_count_threshold < len(processed_tags):
+                processed_tags = [(k, v) for k, v in processed_tags.items()]
+                processed_tags.sort(key=lambda x: x[1], reverse=True)
+                processed_tags = dict(processed_tags[:int(tag_count_threshold)])
 
             if verbose:
                 print(f'{path}: {len(processed_tags)}/{len(tags)} tags found')
@@ -429,6 +434,15 @@ def on_ui_tabs():
                     value=0.35
                 )
 
+                tag_count_threshold = utils.preset.component(
+                    gr.Slider,
+                    label='Tag count threshold',
+                    minimum=0,
+                    maximum=1000,
+                    value=100,
+                    step=1.0
+                )
+
                 additional_tags = utils.preset.component(
                     gr.Textbox,
                     label='Additional tags (split by comma)',
@@ -537,6 +551,7 @@ def on_ui_tabs():
                     # options
                     interrogator,
                     threshold,
+                    tag_count_threshold,
                     additional_tags,
                     exclude_tags,
                     sort_by_alphabetical_order,

--- a/tagger/ui.py
+++ b/tagger/ui.py
@@ -199,9 +199,6 @@ def on_interrogate(
 
             if verbose:
                 print(f'{path}: {len(processed_tags)}/{len(tags)} tags found')
-            else:
-                # go up one line so the bar does not mess up the console
-                print("\033[F", end="")
 
             if batch_output_action_on_conflict == 'replace' or not output:
                 output = [', '.join(processed_tags)]

--- a/tagger/ui.py
+++ b/tagger/ui.py
@@ -78,7 +78,7 @@ def on_interrogate(
             interrogator.unload()
 
         return [
-            ', '.join(processed_tags),
+            ', '.join(processed_tags.keys() if add_confident_as_weight else processed_tags),
             ratings,
             tags,
             ''

--- a/tagger/ui.py
+++ b/tagger/ui.py
@@ -355,7 +355,7 @@ def on_ui_tabs():
                             value='ignore',
                             choices=[
                                 'ignore',
-                                'copy',
+                                'replace',
                                 'append',
                                 'prepend'
                             ]

--- a/tagger/ui.py
+++ b/tagger/ui.py
@@ -333,7 +333,7 @@ def on_interrogate(
     tags = []
     for k, v in combined.items():
         if k[:7] == "rating:":
-            rating_confidents[k[8:]] = v / nr_of_files
+            rating_confidents[k[7:]] = v / nr_of_files
         elif v / nr_of_files >= threshold / 2:
             tag_confidents[k] = v / nr_of_files
             if v / nr_of_files >= threshold:

--- a/tagger/ui.py
+++ b/tagger/ui.py
@@ -233,7 +233,7 @@ def on_interrogate(
                     for k, v in weights.items():
                         combined[k] = combined[k] + v if k in combined else v
                     continue
-            if batch_output_action_on_conflict != 'filter':
+            if batch_output_action_on_conflict != 'update':
                 ratings, tags = interrogator.interrogate(image)
                 processed_tags = Interrogator.postprocess_tags(
                     tags,
@@ -415,7 +415,7 @@ def on_ui_tabs():
                                 'replace',
                                 'append',
                                 'prepend',
-                                'filter'
+                                'update'
                             ]
                         )
 

--- a/tagger/ui.py
+++ b/tagger/ui.py
@@ -169,9 +169,10 @@ def on_interrogate(
             )
 
             if verbose:
-                print(
-                    f'found {len(processed_tags)} tags out of {len(tags)} from {path}'
-                )
+                print(f'{path}: {len(processed_tags)}/{len(tags)} tags found')
+            else:
+                # go up one line so the bar does not mess up the console
+                print("\033[F", end="")
 
             plain_tags = ', '.join(processed_tags)
 

--- a/tagger/ui.py
+++ b/tagger/ui.py
@@ -142,7 +142,7 @@ def on_interrogate(
         rem_tags = set(rem_tags)
 
         def re_comp(x):
-            re.compile('^'+str.strip(x)+'$', flags=re_f)
+            return re.compile('^'+str.strip(x)+'$', flags=re_f)
 
         search_tag_list = list(map(re_comp, search_tags.split(',')))
         replace_tag_list = list(map(str.strip, replace_tags.split(',')))
@@ -247,7 +247,7 @@ def on_interrogate(
                         search = search_tag_list[i]
                         replace = replace_tag_list[i]
 
-                        if replace and re.match(replace, k):
+                        if replace and re.match(search, k):
                             v = weights[k]
                             new_k = re.sub(search, replace, k, 1)
                             if new_k in weights:

--- a/tagger/ui.py
+++ b/tagger/ui.py
@@ -258,11 +258,11 @@ def on_interrogate(
                             k = re.sub(search, replace, k, 1)
                             if k in weights:
                                 v = v + weights[k]
-                            weights[k] = v
+                            weights[k] = min(v, 1)
                             break
 
                 processed_tags = weights
-                tags = weights.keys()
+                tags = list(weights.keys())
                 tags.sort(key=lambda x: weights[x], reverse=True)
                 batch_output_save_json = False
                 output = None

--- a/tagger/ui.py
+++ b/tagger/ui.py
@@ -249,15 +249,16 @@ def on_interrogate(
 
                         if replace and re.match(search, k):
                             v = weights[k]
-                            new_k = re.sub(search, replace, k, 1)
-                            if new_k in weights:
-                                v = v + weights[new_k]
-                            weights[new_k] = v
                             del weights[k]
+                            k = re.sub(search, replace, k, 1)
+                            if k in weights:
+                                v = v + weights[k]
+                            weights[k] = v
                             break
 
                 processed_tags = weights
                 tags = weights.keys()
+                tags.sort(key=lambda x: weights[x], reverse=True)
                 batch_output_save_json = False
                 output = None
 

--- a/tagger/utils.py
+++ b/tagger/utils.py
@@ -86,19 +86,20 @@ def refresh_interrogators() -> List[str]:
 
         #if no file with the extension .onnx is found, skip. If there is more than one file with that name, warn. Else put it in model_path
         onnx_files = [x for x in os.scandir(path) if x.name.endswith('.onnx')]
-        if len(onnx_files) == 0:
-            print(f"Warning: {path} has no model, skipping")
-            continue
-        elif len(onnx_files) > 1:
-            print(f"Warning: {path} has multiple models, skipping")
+        if len(onnx_files) != 1:
+            print(f"Warning: {path} requires exactly one .onnx model, skipping")
             continue
         model_path = Path(path, onnx_files[0].name)
 
-        if not Path(path, 'tags-selected.csv').is_file():
-            print(f"Warning: {path} has a model but no tags-selected.csv file, skipping")
+        csv = [x for x in os.scandir(path) if x.name.endswith('.csv')]
+        if len(csv) == 0:
+            print(f"Warning: {path} has no selected tags .csv file, skipping")
             continue
 
-        interrogators[path.name] = WaifuDiffusionInterrogator(path.name,model_path=model_path, tags_path=Path(path, 'tags-selected.csv'))
+        # sort so that csv files with `tag' or `select' end up front
+        csv.sort(key=lambda k: (-1 if "tag" in k.name.lower() else 1) + (-1 if "select" in k.name.lower() else 1))
+
+        interrogators[path.name] = WaifuDiffusionInterrogator(path.name,model_path=model_path, tags_path=Path(path, csv[0]))
 
     return sorted(interrogators.keys())
 


### PR DESCRIPTION
General:
* Weights, when enabled, are not printed in the tags list. Weights are displayed in the list below already as bars, so they do not add information, only obfuscate the list IMO.
* The list of tags weights now stops at half the threshold, so the list is not overly long, only the just missed ones are listed. This is a somewhat arbitrary choice.
* Add a slider to limit the number of tags emitted to the files. (fixes #61).
* Make the labels listed clickable again, a click will add it to the selected listbox. This should fix #91. And with commit 
6bb0114 the clicked value is actually stored.
* Added search and replace input lists. if weighed, those are added, up to 1.
* Changed behavior: when clicking on the dotted line, inserted is in the exclude/replace input list, if not the tag is inserted in the additional/search input list

For batch processing:
* pre- or appending weights to weighed tag files, i.e. with weights enabled, will instead have the weights averaged, this requires a reference counter that increments with the number of interrogations applied to the tags file. This count is added in the document as a last single float. After reading the file this float is first consumed, before re-averaging the weights.
* After batch processing the combined tag count average is listed, for all processed files, and the corrected average when combining the weighed tags. This is not limited to the tag_count_threshold, as it relates to the weights of all tag files. Conversely, the already existing threshold slider does affect this list length.
* When running ignore on all pre-existing tag files, just the tag statistics, in the right pane, will be shown. I find this also convenient for repopulating the additional_tags while debugging the interface.
* Add an 'update' action, which updates the tag files, thresholds, and adds/removes the additional/ exclusion tags. The stats reflect those changes. This is no interrogation, so just a fast text file update. Adding the regexp solves #29.
* When combining a weighed and writing a non weighted after combination according to weights, a weightless tags file is written. This will also lack the interrogation counter.
* Appending a weights to a non-weighted tags file is not perfect. The missing weights for the tags will be assumed 
to linearly decline, in order of listing, from 1 to 0 in equal steps for the number of tags, and a prior interrogation counter of 1 is assumed, that is used to correct the added weights. A warning is printed.
* added a 'verbose switch'. pressing results in current display, but if left unchecked, then processing of tags files is displayed as a progress bar. This fixes #17.
* a comma was previously missing when appending tags
